### PR TITLE
Bump cmake to 3.14.0-rc4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,12 @@ RUN apt-get update && \
     gem install nokogiri && \    
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /dist && \
-    wget -O /dist/cmake-3.13.0-rc1-Linux-x86_64.sh https://cmake.org/files/v3.13/cmake-3.13.0-rc1-Linux-x86_64.sh && \
+    wget -O /dist/cmake-3.14.0-rc4-Linux-x86_64.sh https://cmake.org/files/v3.14/cmake-3.14.0-rc4-Linux-x86_64.sh && \
     wget -O /dist/sdk-tools-linux-4333796.zip https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && \
     wget -O /dist/android-ndk-r19b-linux-x86_64.zip https://dl.google.com/android/repository/android-ndk-r19b-linux-x86_64.zip && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get -y install nodejs && \
-    sh /dist/cmake-3.13.0-rc1-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    sh /dist/cmake-3.14.0-rc4-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     mkdir -p /usr/local/opt/android-sdk /usr/local/opt/android-ndk && \
     unzip -q -o /dist/sdk-tools-linux-4333796.zip -d /usr/local/opt/android-sdk && \
     yes | /usr/local/opt/android-sdk/tools/bin/sdkmanager \


### PR DESCRIPTION
Adds CMAKE_BUILD_PARALLEL_LEVEL support.